### PR TITLE
Added proposal padding

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1231,3 +1231,10 @@ body.mobile-nav-active #mobile-nav-toggle {
 #footer .footer-links a:hover {
   color: #1dc8cd;
 }
+
+/*--------------------------------------------------------------
+# Proposal
+--------------------------------------------------------------*/
+#proposal {
+  padding-top: 85px;
+}


### PR DESCRIPTION
This change correlated with my other commit of making the nav fixed to the top. This means that the top of the proposal form will be hidden behind the nav and since the nav/header is 78px when fixed *If my submit goes through. The 85px would make sure it is not hidden and also gives a little space between the nav/header and the form.