### PR TITLE
alternative position for intro text section

### DIFF
--- a/css/_header.scss
+++ b/css/_header.scss
@@ -78,7 +78,7 @@
     flex-direction: column;
     height: calc(50% - 60px);
     justify-content: center;
-    position: absolute;
+    position: fixed;
     text-align: center;
   }
 


### PR DESCRIPTION
@kauffj kauffj commented 20 hours ago
@ykris45 the correct solution is not to make the header always sticky. Try altering the styling of the .intro-text, the right solution is likely on that element or something inside of it.
maybe the better way is change the position from absolute to fixed for alternative method of sticky style 

